### PR TITLE
Added Raspberry docker file with GPIO library.

### DIFF
--- a/noderedmodule/Dockerfile.arm32v7-rpi
+++ b/noderedmodule/Dockerfile.arm32v7-rpi
@@ -1,0 +1,21 @@
+FROM arm32v7/node:8-slim
+
+# Install python and rpi.gpio library for GPIO access.
+RUN apt-get -q update && \
+	apt-get -qy install python-dev python-pip gcc && \
+    pip install rpi.gpio
+
+RUN npm install -g --unsafe-perm node-red
+WORKDIR /usr/local/lib/node_modules/node-red/node_modules/node-red-contrib-azure-iot
+
+COPY azureiotedge.js ./
+COPY azureiotedge.html ./
+COPY ./icons/azureiotedge.png ./icons/
+COPY ./examples/* ./examples/
+COPY package*.json ./
+
+RUN npm install --production
+
+EXPOSE 1880/tcp
+
+CMD ["node-red"]

--- a/noderedmodule/package.json
+++ b/noderedmodule/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "<your_name>",
+    "name": "node-red-edge-module",
     "description": "Connector to Azure IoT Edge on Node-Red",
     "version": "0.1.1",
     "engines": {


### PR DESCRIPTION
### Raspberry GPIO Access
I noticed the GPIO headers were not available on Raspberry Pi. I added a new Dockerfile with the following changes:
- Installing Python library for GPIO access.
- No longer switching to a new user, because then the GPIO service is inaccessible.

package.json was updated with a name. The name <your_name> resulted in no packages being installed.

New Docker Image is pushed to matthijsvdveer/noderededgemodule:0.1.0-arm32v7-rpi if you want to give it a go. **Note:** This new image is 442MB, where your version is 221MB. I checked and it seems to be that python-dev and the GPIO library add lot of data.