### PR TITLE
Fixed bug to direct method calls with JSON payload

### DIFF
--- a/noderedmodule/azureiotedge.js
+++ b/noderedmodule/azureiotedge.js
@@ -211,7 +211,7 @@ module.exports = function (RED) {
 
                 if(request.payload) {
                     node.log('Method Payload:' + JSON.stringify(request.payload));
-                    node.send({payload: JSON.parse(request.payload),topic: "method", method: request.methodName});
+                    node.send({payload: request.payload,topic: "method", method: request.methodName});
                 }
                 else {
                     node.send({payload: null,topic: "method", method: request.methodName});


### PR DESCRIPTION
JSON.parse being used on request.payload of type object.  Direct method without JSON payload already working as expected