### PR TITLE
Correct malformed JSON in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     "Privileged": true,
     "Binds":[
         "/data:/data"
-    ]
+    ],
     "PortBindings": {
       "1880/tcp": [
         {


### PR DESCRIPTION
Very small typo in the example createOptions which means the JSON is malformed. Would be nice to correct this since you end up copying the json out and correcting every time.