### PR TITLE
Allow settings persistance across restarts

### DIFF
--- a/noderedmodule/Dockerfile.amd64
+++ b/noderedmodule/Dockerfile.amd64
@@ -18,4 +18,4 @@ EXPOSE 1880/tcp
 
 USER node
 
-CMD ["node-red"]
+CMD ["node-red", "--userDir", "/data/noderededgemodule", "--flowFile", "flows_noderededgemodule.json"]

--- a/noderedmodule/Dockerfile.arm32v7
+++ b/noderedmodule/Dockerfile.arm32v7
@@ -18,4 +18,4 @@ EXPOSE 1880/tcp
 
 USER node
 
-CMD ["node-red"]
+CMD ["node-red", "--userDir", "/data/noderededgemodule", "--flowFile", "flows_noderededgemodule.json"]


### PR DESCRIPTION
Currently the Dockerfile does not include the necessary options to put the Node-RED settings and flows into the data folder which is then bound. This PR just adds the necessary arguments to the CMD in order:
* to store everything in /data 
* keep the flows.json filename consistent since it includes hostname which changes on container restart