### PR TITLE
Added contentType and contentEncoding to Edge Message output

### DIFF
--- a/node-red-contrib-azure-iot-edge-module/azureiotedge.js
+++ b/node-red-contrib-azure-iot-edge-module/azureiotedge.js
@@ -374,6 +374,11 @@ module.exports = function (RED) {
         }
         node.log('Sending Message to Azure IoT Edge: ' + output + '\n   Payload: ' + JSON.stringify(message));
         var msg = new Message(JSON.stringify(message));
+        
+        //Assuming only json payload
+        msg.contentType = "application/json";
+        msg.contentEncoding = "utf-8";
+        
         client.sendOutputEvent(output, msg, function (err, res) {
             if (err) {
                 node.error('Error while trying to send message:' + err.toString());


### PR DESCRIPTION
For IoT Hub routing and usage of edge messages on the cloud it is essential to correctly define contentType and contentEncoding parameters to the message.

For now the two parameters are fixed, also because all the logic assume that the payload must be a Json message.